### PR TITLE
Fix crash when dispatching to handleSingleTap:

### DIFF
--- a/PASImageView.swift
+++ b/PASImageView.swift
@@ -119,13 +119,14 @@ public class PASImageView : UIView, NSURLSessionDownloadDelegate {
         updatePaths()
     }
     
-    
-    //MARK:- Private methods
-    
-    private func handleSingleTap(gesture: UIGestureRecognizer) {
+    //MARK:- Obj-C action
+
+    func handleSingleTap(gesture: UIGestureRecognizer) {
         delegate?.PAImageView(didTapped: self)
     }
     
+    //MARK:- Private methods
+
     private func setConstraints() {
         
         // containerImageView


### PR DESCRIPTION
Hi Pierre, 

I've had an "unknown selector" crash when tapping on PASImageView. The reason seems to be the private modifier on handleSingleTap function – everything works once I remove it.

Thanks, Ilya.
